### PR TITLE
Show file name of test reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,13 +33,19 @@
     <dependency>
       <groupId>edu.hm.hafner</groupId>
       <artifactId>analysis-model</artifactId>
-      <version>9.1.0</version>
+      <version>9.2.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>github-api</artifactId>
       <version>1.116</version>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.8.0</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/edu/hm/hafner/grading/AnalysisReportSupplier.java
+++ b/src/main/java/edu/hm/hafner/grading/AnalysisReportSupplier.java
@@ -11,16 +11,10 @@ import edu.hm.hafner.analysis.parser.violations.PitAdapter;
  *
  * @author Ullrich Hafner
  */
-public class AnalysisReportSupplier extends AnalysisSupplier {
+class AnalysisReportSupplier extends AnalysisSupplier {
     private final List<AnalysisScore> analysisReports;
 
-    /**
-     * Creates a new instance of {@link AnalysisReportSupplier}.
-     *
-     * @param analysisReports
-     *         the static analysis reports
-     */
-    public AnalysisReportSupplier(final List<AnalysisScore> analysisReports) {
+    AnalysisReportSupplier(final List<AnalysisScore> analysisReports) {
         this.analysisReports = analysisReports;
     }
 

--- a/src/main/java/edu/hm/hafner/grading/AutoGradingAction.java
+++ b/src/main/java/edu/hm/hafner/grading/AutoGradingAction.java
@@ -30,7 +30,6 @@ import de.tobiasmichael.me.Util.JacocoReport;
  */
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class AutoGradingAction {
-
     private static final String JACOCO_RESULTS = "target/site/jacoco/jacoco.xml";
 
     /**
@@ -60,12 +59,12 @@ public class AutoGradingAction {
         score.addPitScores(new PitReportSupplier(pitReports));
 
         List<AnalysisScore> analysisReports = new ArrayList<>();
-        Report pmdReport = new PmdParser().parse(read("target/pmd.xml"));
-        analysisReports.add(createAnalysisScore(analysisConfiguration, "PMD", "pmd",
-                pmdReport));
         Report checkStyleReport = new CheckStyleParser().parse(read("target/checkstyle-result.xml"));
         analysisReports.add(createAnalysisScore(analysisConfiguration, "CheckStyle", "checkstyle",
                 checkStyleReport));
+        Report pmdReport = new PmdParser().parse(read("target/pmd.xml"));
+        analysisReports.add(createAnalysisScore(analysisConfiguration, "PMD", "pmd",
+                pmdReport));
         Report spotBugsReport = new FindBugsParser(PriorityProperty.RANK).parse(read("target/spotbugsXml.xml"));
         analysisReports.add(createAnalysisScore(analysisConfiguration, "SpotBugs", "spotbugs",
                 spotBugsReport));

--- a/src/main/java/edu/hm/hafner/grading/CoverageReportSupplier.java
+++ b/src/main/java/edu/hm/hafner/grading/CoverageReportSupplier.java
@@ -6,14 +6,14 @@ import java.util.List;
 import de.tobiasmichael.me.Util.JacocoReport;
 
 /**
- * FIXME: comment class.
+ * Provides code coverage scores by converting corresponding {@link JacocoReport} instances.
  *
  * @author Ullrich Hafner
  */
-public class CoverageReportSupplier extends CoverageSupplier {
+class CoverageReportSupplier extends CoverageSupplier {
     private final JacocoReport coverageReport;
 
-    public CoverageReportSupplier(final JacocoReport coverageReport) {
+    CoverageReportSupplier(final JacocoReport coverageReport) {
         this.coverageReport = coverageReport;
     }
 

--- a/src/main/java/edu/hm/hafner/grading/FileNameRenderer.java
+++ b/src/main/java/edu/hm/hafner/grading/FileNameRenderer.java
@@ -1,0 +1,19 @@
+package edu.hm.hafner.grading;
+
+import org.apache.commons.io.FilenameUtils;
+
+import edu.hm.hafner.analysis.Report;
+import edu.hm.hafner.util.PathUtil;
+
+/**
+ * Renders the file name for a {@link Report}.
+ *
+ * @author Ullrich Hafner
+ */
+class FileNameRenderer {
+    private static final PathUtil PATH_UTIL = new PathUtil();
+
+    String getFileName(final Report report, final String defaultFileName) {
+        return FilenameUtils.getBaseName(report.getFileNames().stream().findAny().orElse(defaultFileName));
+    }
+}

--- a/src/main/java/edu/hm/hafner/grading/FileNameRenderer.java
+++ b/src/main/java/edu/hm/hafner/grading/FileNameRenderer.java
@@ -3,7 +3,6 @@ package edu.hm.hafner.grading;
 import org.apache.commons.io.FilenameUtils;
 
 import edu.hm.hafner.analysis.Report;
-import edu.hm.hafner.util.PathUtil;
 
 /**
  * Renders the file name for a {@link Report}.
@@ -11,8 +10,6 @@ import edu.hm.hafner.util.PathUtil;
  * @author Ullrich Hafner
  */
 class FileNameRenderer {
-    private static final PathUtil PATH_UTIL = new PathUtil();
-
     String getFileName(final Report report, final String defaultFileName) {
         return FilenameUtils.getBaseName(report.getFileNames().stream().findAny().orElse(defaultFileName));
     }

--- a/src/main/java/edu/hm/hafner/grading/GradingResults.java
+++ b/src/main/java/edu/hm/hafner/grading/GradingResults.java
@@ -9,7 +9,7 @@ import edu.hm.hafner.analysis.Report;
  *
  * @author Tobias Effner
  */
-public class GradingResults {
+class GradingResults {
     /**
      * Creates a summary comment in Markdown.
      *

--- a/src/main/java/edu/hm/hafner/grading/PitReportFinder.java
+++ b/src/main/java/edu/hm/hafner/grading/PitReportFinder.java
@@ -46,7 +46,7 @@ public class PitReportFinder extends ReportFinder {
         PitAdapter parser = new PitAdapter();
         return reportFiles.stream()
                 .map(FileReaderFactory::new)
-                .map(parser::parse)
+                .map(parser::parseFile)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/PitReportFinder.java
+++ b/src/main/java/edu/hm/hafner/grading/PitReportFinder.java
@@ -1,30 +1,18 @@
 package edu.hm.hafner.grading;
 
-import java.io.IOException;
-import java.nio.file.FileSystems;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import edu.hm.hafner.analysis.FileReaderFactory;
 import edu.hm.hafner.analysis.Report;
-import edu.hm.hafner.analysis.parser.violations.JUnitAdapter;
 import edu.hm.hafner.analysis.parser.violations.PitAdapter;
 
 /**
- * Finds JUnit test reports in the file system.
- *
- * @author Ullrich Hafner
+ * Provides PIT mutation coverage scores by converting corresponding {@link Report} instances.
  */
-public class PitReportFinder extends ReportFinder {
+class PitReportFinder extends ReportFinder {
     private static final String PIT_REPORT_PATTERN = "target/pit-reports/";
 
     /**

--- a/src/main/java/edu/hm/hafner/grading/PitReportSupplier.java
+++ b/src/main/java/edu/hm/hafner/grading/PitReportSupplier.java
@@ -12,6 +12,8 @@ import edu.hm.hafner.analysis.parser.violations.PitAdapter;
  * @author Ullrich Hafner
  */
 public class PitReportSupplier extends PitSupplier {
+    private static final FileNameRenderer RENDERER = new FileNameRenderer();
+
     private final List<Report> pitReports;
 
     /**
@@ -35,7 +37,7 @@ public class PitReportSupplier extends PitSupplier {
     private PitScore createPitScore(final PitConfiguration configuration, final Report report) {
         return new PitScore.PitScoreBuilder()
                 .withConfiguration(configuration)
-                .withDisplayName("PIT")
+                .withDisplayName(RENDERER.getFileName(report, "PIT"))
                 .withTotalMutations(report.getCounter(PitAdapter.TOTAL_MUTATIONS))
                 .withUndetectedMutations(report.getCounter(PitAdapter.SURVIVED_MUTATIONS))
                 .build();

--- a/src/main/java/edu/hm/hafner/grading/PitReportSupplier.java
+++ b/src/main/java/edu/hm/hafner/grading/PitReportSupplier.java
@@ -11,18 +11,12 @@ import edu.hm.hafner.analysis.parser.violations.PitAdapter;
  *
  * @author Ullrich Hafner
  */
-public class PitReportSupplier extends PitSupplier {
+class PitReportSupplier extends PitSupplier {
     private static final FileNameRenderer RENDERER = new FileNameRenderer();
 
     private final List<Report> pitReports;
 
-    /**
-     * Creates a new instance of {@link PitReportSupplier}.
-     *
-     * @param pitReports
-     *         the PIT mutation reports
-     */
-    public PitReportSupplier(final List<Report> pitReports) {
+    PitReportSupplier(final List<Report> pitReports) {
         this.pitReports = pitReports;
     }
 

--- a/src/main/java/edu/hm/hafner/grading/TestReportFinder.java
+++ b/src/main/java/edu/hm/hafner/grading/TestReportFinder.java
@@ -36,7 +36,7 @@ public class TestReportFinder extends ReportFinder {
         JUnitAdapter parser = new JUnitAdapter();
         return reportFiles.stream()
                 .map(FileReaderFactory::new)
-                .map(parser::parse)
+                .map(parser::parseFile)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/edu/hm/hafner/grading/TestReportFinder.java
+++ b/src/main/java/edu/hm/hafner/grading/TestReportFinder.java
@@ -14,7 +14,7 @@ import edu.hm.hafner.analysis.parser.violations.JUnitAdapter;
  *
  * @author Ullrich Hafner
  */
-public class TestReportFinder extends ReportFinder {
+class TestReportFinder extends ReportFinder {
     private static final String SUREFIRE_REPORT_PATTERN = "target/surefire-reports/";
 
     /**
@@ -30,6 +30,7 @@ public class TestReportFinder extends ReportFinder {
             return Collections.emptyList();
         }
 
+        Collections.sort(reportFiles);
         System.out.println("Reading test results: ");
         System.out.println(reportFiles);
 

--- a/src/main/java/edu/hm/hafner/grading/TestReportSupplier.java
+++ b/src/main/java/edu/hm/hafner/grading/TestReportSupplier.java
@@ -12,6 +12,8 @@ import edu.hm.hafner.analysis.parser.violations.JUnitAdapter;
  * @author Ullrich Hafner
  */
 public class TestReportSupplier extends TestSupplier {
+    private static final FileNameRenderer RENDERER = new FileNameRenderer();
+
     private final List<Report> testReports;
 
     /**
@@ -34,7 +36,7 @@ public class TestReportSupplier extends TestSupplier {
     private TestScore createTestScore(final TestConfiguration configuration, final Report report) {
         return new TestScore.TestScoreBuilder()
                 .withConfiguration(configuration)
-                .withDisplayName("JUnit")
+                .withDisplayName(RENDERER.getFileName(report, "JUnit"))
                 .withTotalSize(report.getCounter(JUnitAdapter.TOTAL_TESTS))
                 .withFailedSize(report.getCounter(JUnitAdapter.FAILED_TESTS))
                 .build();

--- a/src/main/java/edu/hm/hafner/grading/TestReportSupplier.java
+++ b/src/main/java/edu/hm/hafner/grading/TestReportSupplier.java
@@ -3,6 +3,8 @@ package edu.hm.hafner.grading;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
+
 import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.parser.violations.JUnitAdapter;
 
@@ -11,18 +13,12 @@ import edu.hm.hafner.analysis.parser.violations.JUnitAdapter;
  *
  * @author Ullrich Hafner
  */
-public class TestReportSupplier extends TestSupplier {
+class TestReportSupplier extends TestSupplier {
     private static final FileNameRenderer RENDERER = new FileNameRenderer();
 
     private final List<Report> testReports;
 
-    /**
-     * Creates a new instance of {@link TestReportSupplier}.
-     *
-     * @param testReports
-     *         the JUnit test reports
-     */
-    public TestReportSupplier(final List<Report> testReports) {
+    TestReportSupplier(final List<Report> testReports) {
         this.testReports = testReports;
     }
 
@@ -36,7 +32,7 @@ public class TestReportSupplier extends TestSupplier {
     private TestScore createTestScore(final TestConfiguration configuration, final Report report) {
         return new TestScore.TestScoreBuilder()
                 .withConfiguration(configuration)
-                .withDisplayName(RENDERER.getFileName(report, "JUnit"))
+                .withDisplayName(StringUtils.removeStart(RENDERER.getFileName(report, "JUnit"), "TEST-"))
                 .withTotalSize(report.getCounter(JUnitAdapter.TOTAL_TESTS))
                 .withFailedSize(report.getCounter(JUnitAdapter.FAILED_TESTS))
                 .build();


### PR DESCRIPTION
Shows the filenames of the JUnit reports so that it is easier to spot which tests are actually broken. Also, sort test report lexicographically so that is is easier to follow.