### PR TITLE
Bump version of autograding-model to 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <docker-image-tag>${project.version}</docker-image-tag>
     <docker-image-baseline>v5-SNAPSHOT</docker-image-baseline>
 
-    <autograding-model.version>5.6.0</autograding-model.version>
+    <autograding-model.version>6.0.0</autograding-model.version>
     <github-api.version>1.327</github-api.version>
     <testcontainers.version>1.20.6</testcontainers.version>
 


### PR DESCRIPTION
Use latest version of autograding the fixes rendering of tables.